### PR TITLE
replace pyproject.toml documentation variable

### DIFF
--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -12,7 +12,7 @@ license = "{{ cookiecutter.license }}"
 readme = "README.md"
 homepage = "https://github.com/{{ cookiecutter.github_user }}/{{ cookiecutter.package_name }}"
 repository = "https://github.com/{{ cookiecutter.github_user }}/{{ cookiecutter.package_name }}"
-documentation = "README.md"
+documentation = "https://README.md"
 classifiers = [
     # https://pypi.org/classifiers/
     {%- if cookiecutter.command_line_interface != "no cli" %}


### PR DESCRIPTION
fix https://github.com/timhughes/cookiecutter-poetry/issues/19

recent version off poetry fail to build if tool.poetry.documentation is not an uri 
i replaced the variable documentation from "README.md" to "https://README.md"
